### PR TITLE
Add Jest setup and basic API tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -11,5 +11,9 @@
   "description": "",
   "dependencies": {
     "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -48,6 +48,10 @@ app.post('/orders', (req, res) => {
   });
 });
 
-app.listen(port, () => {
-  console.log(`Servidor corriendo en http://localhost:${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Servidor corriendo en http://localhost:${port}`);
+  });
+}
+
+module.exports = { app, menu };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,18 @@
+const request = require('supertest');
+const { app, menu } = require('../server');
+
+describe('API endpoints', () => {
+  test('GET /menu returns menu array', async () => {
+    const response = await request(app).get('/menu');
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(menu);
+  });
+
+  test('POST /orders accepts an order', async () => {
+    const order = [{ id: 1, name: '🍕 Pizza', price: 50000, category: 'cena', quantity: 1 }];
+    const response = await request(app).post('/orders').send(order);
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty('message', 'Pedido recibido con éxito');
+    expect(response.body).toHaveProperty('order');
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app from `server.js` for testing
- add Jest & Supertest dev dependencies
- write tests for `GET /menu` and `POST /orders`
- provide npm test script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d29784dc83239b26a655a0bfb4f3